### PR TITLE
Pullrequest workaround for tests

### DIFF
--- a/src/main/java/org/simlar/simlarserver/services/settingsservice/SettingsService.java
+++ b/src/main/java/org/simlar/simlarserver/services/settingsservice/SettingsService.java
@@ -35,7 +35,7 @@ public final class SettingsService {
     private final String version;
 
     @Autowired // fix IntelliJ inspection warning unused
-    private SettingsService(
+    public SettingsService(
             @Value("${domain:}") final String                                      domain,
             @Value("${port:6161}") final short                                     port,
             @Value("${info.app.version:}") final String                            version

--- a/src/test/java/org/simlar/simlarserver/services/pushnotification/ApplePushNotificationTest.java
+++ b/src/test/java/org/simlar/simlarserver/services/pushnotification/ApplePushNotificationTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assume.assumeTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SimlarServer.class)
-public final class ApplePushNotificationServerConnectionTest {
+public final class ApplePushNotificationTest {
     @Autowired
     private PushNotificationSettingsService pushNotificationSettings;
 

--- a/src/test/java/org/simlar/simlarserver/services/twilio/TwilioSmsServiceTest.java
+++ b/src/test/java/org/simlar/simlarserver/services/twilio/TwilioSmsServiceTest.java
@@ -33,8 +33,6 @@ import org.simlar.simlarserver.services.settingsservice.SettingsService;
 import org.simlar.simlarserver.services.smsservice.SmsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -47,12 +45,11 @@ import static org.mockito.Mockito.when;
 import static org.simlar.simlarserver.helper.Asserts.assertAlmostEquals;
 import static org.simlar.simlarserver.helper.Asserts.assertAlmostEqualsContainsError;
 
-@DirtiesContext // setting the domain properties dirties context
-@TestPropertySource(properties = "domain = sip.simlar.org") // domain is an essential part of the callback url
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SimlarServer.class)
 public final class TwilioSmsServiceTest {
-    @Autowired
+    private SettingsService settingsService;
+
     private TwilioSmsService twilioSmsService;
 
     @Autowired
@@ -61,13 +58,13 @@ public final class TwilioSmsServiceTest {
     @Autowired
     private SmsProviderLogRepository smsProviderLogRepository;
 
-    @Autowired
-    private SettingsService settingsService;
-
     @Before
-    public void verifyConfiguration() {
+    public void setup() {
         assumeTrue("This test needs a Twilio configuration with Twilio test credentials", twilioSettingsService.isConfigured());
         assertEquals("Twilio test credentials", "+15005550006", twilioSettingsService.getSmsSourceNumber());
+
+        settingsService = new SettingsService("sip.simlar.org", (short)6161, "test");
+        twilioSmsService = new TwilioSmsService(settingsService, twilioSettingsService, smsProviderLogRepository);
     }
 
     @Test


### PR DESCRIPTION
Hi @jritzerfeld,
this definitely is a workaround. But this workaround actually still works when adding more tests.
And it speeds up test execution overall :)
However, I guess, in the long run CreateAccountServiceTest needs some refactoring.
Cheers,
 Ben